### PR TITLE
Updated StakingManager's tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 <p align="center">
   <img src="https://github.com/jigsaw-finance/jigsaw-lite/assets/102415071/894b1ec7-dcbd-4b2d-ac5d-0a9d0df26313" alt="jigsaw 2"><br>
-  <a href="https://github.com/groksmith/jigsaw-lite/actions/workflows/test.yml">
-    <img src="https://github.com/groksmith/jigsaw-lite/actions/workflows/test.yml/badge.svg" alt="test">
+  <a href="https://github.com/jigsaw-finance/jigsaw-lite/actions/workflows/test.yml">
+    <img src="https://github.com/jigsaw-finance/jigsaw-lite/actions/workflows/test.yml/badge.svg" alt="test">
   </a>
-  <a href="https://github.com/groksmith/jigsaw-lite/blob/main/LICENSE">
+  <a href="https://github.com/jigsaw-finance/jigsaw-lite/blob/main/LICENSE">
     <img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT">
   </a>
   <img src="https://img.shields.io/github/commit-activity/m/statping/statping.svg" alt="GitHub commit activity">

--- a/test/StakingManager/StakingManager_fork.t.sol
+++ b/test/StakingManager/StakingManager_fork.t.sol
@@ -15,6 +15,7 @@ import { IStaker } from "../../src/interfaces/IStaker.sol";
 import { IWhitelist } from "../utils/IWhitelist.sol";
 
 IIonPool constant ION_POOL = IIonPool(0x0000000000eaEbd95dAfcA37A39fd09745739b78);
+IWhitelist constant ION_WHITELIST = IWhitelist(0x7E317f99aA313669AaCDd8dB3927ff3aCB562dAD);
 
 contract StakingManagerForkTest is Test {
     error PreLockupPeriodUnstaking();
@@ -59,7 +60,7 @@ contract StakingManagerForkTest is Test {
         vm.startPrank(ION_POOL.owner());
         ION_POOL.updateIlkDebtCeiling(0, type(uint256).max);
         ION_POOL.updateSupplyCap(type(uint256).max);
-        IWhitelist(ION_POOL.whitelist()).approveProtocolWhitelist(address(stakingManager));
+        ION_WHITELIST.approveProtocolWhitelist(address(stakingManager));
         vm.stopPrank();
     }
 


### PR DESCRIPTION
As Ion Protocol updated their pool implementation, whitelist function
became no longer available, thus had to hardcode Ion's Whitelist Contract's
address to make tests pass.